### PR TITLE
Collect dimnames into a Array of strings

### DIFF
--- a/ext/ZarrExt.jl
+++ b/ext/ZarrExt.jl
@@ -49,7 +49,7 @@ Base.haskey(ds::ZarrDataset, k) = haskey(ds.g, k)
 
 function YAB.add_var(p::ZarrDataset, T::Type, varname, s, dimnames, attr;
   chunksize=s, fill_as_missing=false, kwargs...)
-  attr2 = merge(attr, Dict("_ARRAY_DIMENSIONS" => reverse(collect(dimnames))))
+  attr2 = merge(attr, Dict("_ARRAY_DIMENSIONS" => reverse(collect(String, dimnames))))
   fv = get(attr, "_FillValue", get(attr, "missing_value", YAB.defaultfillval(T)))
   attr3 = filter(attr2) do (k, v)
     !isa(v, AbstractFloat) || !isnan(v)

--- a/test/datasets.jl
+++ b/test/datasets.jl
@@ -78,6 +78,16 @@ end
     @test allow_missings(ds_zarr) == false
   end
 end
+
+@testset "Writing and loading zerodim Zarr" begin
+  path = tempname() * "testdatazerodim.zarr"
+  ds = create_empty(YAXArrayBase.backendlist[:zarr], path)
+  add_var(ds, fill(1), "layer", (), Dict{String, Any}())
+  ds_loaded = to_dataset(path, driver=:zarr)
+  @test ds_loaded["layer"][] == 1
+  @test ds_loaded["layer"].attrs["_ARRAY_DIMENSIONS"] == []
+end
+
 @testset "Reading ArchGDAL" begin
   using ArchGDAL
   import Downloads


### PR DESCRIPTION
This fixes the writing and reloading of zerodimensional arrays.

This also adds a test for the writing and reading of a zerodim array. 

This is failing for me locally with a seemingly unrelated failure from iscompressed. 

@meggart 